### PR TITLE
Set main to index.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "combine-source-map",
   "version": "0.1.2",
   "description": "Add source maps of multiple files, offset them and then combine them into one source map",
-  "main": "combine-source-map.js",
+  "main": "index.js",
   "scripts": {
     "test": "node-trap test/*.js"
   },


### PR DESCRIPTION
Minor change to make the main field in the package.json point to the right file, index.js.

Much like the issue that I reported earlier in brace:
  https://github.com/thlorenz/brace/pull/1
