### PR TITLE
Remove all sourceMappingURL comment types

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,5 +94,5 @@ exports.create = function (file, sourceRoot) { return new Combiner(file, sourceR
  */
 exports.removeComments = function (src) {
   if (!src.replace) return src;
-  return src.replace(convert.commentRegex, '');
+  return src.replace(convert.commentRegex, '').replace(convert.mapFileCommentRegex, '');
 };


### PR DESCRIPTION
The removeComments function was only removing the sourceMappingURL for embedded (inlined) sources and not map file URLs. This fix removes both comment types.

Because Browserify through browser-pack depends on this module, this ensures that only a single sourceMappingURL is present in the file.

When multiple maps were present, gulp-sourcemaps, Safari, and other developer tools would only read the first map and miss the combined one at the end.