### PR TITLE
Fix multiple sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,5 +94,5 @@ exports.create = function (file, sourceRoot) { return new Combiner(file, sourceR
  */
 exports.removeComments = function (src) {
   if (!src.replace) return src;
-  return src.replace(convert.commentRegex, '');
+  return src.replace(convert.commentRegex, '').replace(convert.mapFileCommentRegex, '');
 };

--- a/index.js
+++ b/index.js
@@ -27,11 +27,20 @@ Combiner.prototype._addGeneratedMap = function (sourceFile, source, offset) {
 Combiner.prototype._addExistingMap = function (sourceFile, source, existingMap, offset) {
   var mappings = mappingsFromMap(existingMap);
 
-  var originalSource = existingMap.sourcesContent[0]
-    , originalSourceFile = existingMap.sources[0];
+  // Add the all of the source from the maps.
+  for (var i = 0, len = existingMap.sources.length; i < len; i++){
+    if (!existingMap.sourcesContent) continue;
 
-  this.generator.addMappings(originalSourceFile || sourceFile, mappings, offset);
-  this.generator.addSourceContent(originalSourceFile || sourceFile, originalSource);
+    this.generator.addSourceContent(existingMap.sources[i], existingMap.sourcesContent[i]);
+  }
+
+  // Add the mappings, preserving the original mapping 'source'.
+  mappings.forEach(function(mapping){
+    // Add the mappings one at a time because 'inline-source-map' doesn't properly handle
+    // mapping source filenames.
+    this.generator.addMappings(mapping.source, [mapping], offset);
+  }, this);
+
   return this;
 };
 

--- a/lib/mappings-from-map.js
+++ b/lib/mappings-from-map.js
@@ -13,10 +13,10 @@ module.exports = function (map) {
   consumer.eachMapping(function (mapping) {
     // only set source if we have original position to handle edgecase (see inline-source-map tests)
     mappings.push({
-      original: {
+      original: mapping.originalColumn != null ? {
         column: mapping.originalColumn
       , line: mapping.originalLine
-      }
+      } : undefined
     , generated: {
         column: mapping.generatedColumn
       , line: mapping.generatedLine


### PR DESCRIPTION
This fix enables support for sourcemaps from multiple files. It includes Logan's original fix plus a patch for relative paths and the removal of sourcemap file URLs that were being left behind.

This makes it possible to use sourcemaps with Browserify.