### PR TITLE
Fix path rebase

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,11 @@
 
 var path            =  require('path');
 var convert         =  require('convert-source-map');
+var pathIsAbsolute  =  require('path-is-absolute');
 var createGenerator =  require('inline-source-map');
 var mappingsFromMap =  require('./lib/mappings-from-map');
 
-function isAbsolutePath(p) {
-  return /^(?:\/|[a-z]+:\/\/)/.test(p)
-	|| path.resolve(p) == path.normalize(p);
-}
+var protocolRx = /^[a-z]+:\/\//;
 
 /**
  * Rebases a relative path in 'sourceFile' to be relative
@@ -35,8 +33,9 @@ function rebaseRelativePath(sourceFile, relativeRoot, relativePath) {
   // join relative path to root (e.g. 'src/' + 'file.js')
   var relativeRootedPath = relativeRoot ? path.join(relativeRoot, relativePath) : relativePath;
 
-  // absolute path does not need rebasing
-  if (isAbsolutePath(relativeRootedPath)) {
+  if (sourceFile === relativeRootedPath ||    // same path,
+      pathIsAbsolute(relativeRootedPath) ||   // absolute path, nor
+      protocolRx.test(relativeRootedPath)) {  // absolute protocol need rebasing
     return relativeRootedPath;
   }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var path            =  require('path');
 var convert         =  require('convert-source-map');
+var memoize         =  require('lodash.memoize');
 var pathIsAbsolute  =  require('path-is-absolute');
 var createGenerator =  require('inline-source-map');
 var mappingsFromMap =  require('./lib/mappings-from-map');
@@ -25,7 +26,7 @@ var protocolRx = /^[a-z]+:\/\//;
  * @param relativeRoot {String} sourceRoot in sourceFile's map to combine with relativePath
  * @param relativePath {String} source path from sourceFile's map
  */
-function rebaseRelativePath(sourceFile, relativeRoot, relativePath) {
+var rebaseRelativePath = memoize(function(sourceFile, relativeRoot, relativePath) {
   if (!relativePath) {
     return relativePath;
   }
@@ -41,7 +42,9 @@ function rebaseRelativePath(sourceFile, relativeRoot, relativePath) {
 
   // make relative to source file
   return path.join(path.dirname(sourceFile), relativeRootedPath);
-}
+}, function(a, b, c) {
+  return a + '::' + b + '::' + c;
+});
 
 function resolveMap(source) {
   var gen = convert.fromSource(source);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "inline-source-map": "~0.5.0",
     "convert-source-map": "~0.3.0",
+    "path-is-absolute": "^1.0.0",
     "source-map": "~0.1.31"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   },
   "homepage": "https://github.com/thlorenz/combine-source-map",
   "dependencies": {
+    "convert-source-map": "^1.1.0",
     "inline-source-map": "~0.5.0",
-    "convert-source-map": "~0.3.0",
     "lodash.memoize": "^3.0.3",
     "path-is-absolute": "^1.0.0",
-    "source-map": "~0.1.31"
+    "source-map": "~0.4.2"
   },
   "devDependencies": {
     "tap": "~0.4.3"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "inline-source-map": "~0.5.0",
     "convert-source-map": "~0.3.0",
+    "lodash.memoize": "^3.0.3",
     "path-is-absolute": "^1.0.0",
     "source-map": "~0.1.31"
   },

--- a/test/combine-source-map.js
+++ b/test/combine-source-map.js
@@ -278,6 +278,54 @@ test('relative path from multiple files', function(t) {
   t.end()
 });
 
+test('relative path when source and file name are the same', function(t) {
+  var gen1Map = {
+    version: 3,
+    sources: [ 'a/b/one.js' ],
+    names: [],
+    mappings: 'AAAA',
+    file: 'a/b/one.js',
+    sourcesContent: [ 'console.log(1);\n' ]
+  };
+
+  var gen2Map = {
+    version: 3,
+    sources: [ 'a/b/two.js' ],
+    names: [],
+    mappings: 'AAAA',
+    file: 'a/b/two.js',
+    sourcesContent: [ 'console.log(2);\n' ]
+  };
+
+  var base64 = combine.create()
+    .addFile({
+      source: 'console.log(1);\n' + convert.fromObject(gen1Map).toComment(),
+      sourceFile: 'a/b/one.js'
+    })
+    .addFile({
+      source: 'console.log(2);\n' + convert.fromObject(gen2Map).toComment(),
+      sourceFile: 'a/b/two.js'
+    }, {line: 1})
+    .base64()
+
+  var sm = convert.fromBase64(base64).toObject();
+
+  t.deepEqual(sm.sources, ['a/b/one.js', 'a/b/two.js'],
+    'include the correct source');
+
+  t.deepEqual(
+      mappingsFromMap(sm)
+    , [ { original: { column: 0, line: 1 },
+        generated: { column: 0, line: 1 },
+        source: 'a/b/one.js',
+        name: undefined },
+      { original: { column: 0, line: 1 },
+        generated: { column: 0, line: 2 },
+        source: 'a/b/two.js',
+        name: undefined } ], 'should properly map multiple files');
+  t.end()
+});
+
 test('remove comments', function (t) {
   var mapComment = convert.fromObject(foo).toComment();
 


### PR DESCRIPTION
I was about to bump browserify's browser-pack's combine-source-map when I noticed that my source map paths were "doubling up" and that my rebuilds were a bit slower.

The paths doubling up was because sourcemaps from transforms (like babel) typically don't get written out to a different path and then re-consumed. So the sources' path and the sourceFile are typically the same. So if you had "app/components/Widget.jsx", you'd end up with "app/components/app/components/Widget.jsx". This fixes that and I added a test.

I'm not sure what the purpose of `path.resolve(p) == path.normalize(p);` was. Since `path.resolve` will always return an absolute path, then if it would equal `path.normalize`, then it would've matched by the regex to begin with. I switched the absolute path tester to sindresorhus's [path-is-absolute](https://github.com/sindresorhus/path-is-absolute) - which is like Node 0.12.0's `path.isAbsolute`.

If you're using combine-source-map in an incremental build pipeline, all those (slow) `path` calls start to add up, so I memoized`rebaseRelativePath`.

cc: @aarononeal 