### PR TITLE
Fix rebaseRelativePath on Windows (backslash)

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var rebaseRelativePath = memoize(function(sourceFile, relativeRoot, relativePath
   }
 
   // join relative path to root (e.g. 'src/' + 'file.js')
-  var relativeRootedPath = relativeRoot ? path.join(relativeRoot, relativePath) : relativePath;
+  var relativeRootedPath = relativeRoot ? path.join(relativeRoot, relativePath).replace(/\\/g, '/') : relativePath;
 
   if (sourceFile === relativeRootedPath ||    // same path,
       pathIsAbsolute(relativeRootedPath) ||   // absolute path, nor
@@ -41,7 +41,7 @@ var rebaseRelativePath = memoize(function(sourceFile, relativeRoot, relativePath
   }
 
   // make relative to source file
-  return path.join(path.dirname(sourceFile), relativeRootedPath);
+  return path.join(path.dirname(sourceFile), relativeRootedPath).replace(/\\/g, '/');
 }, function(a, b, c) {
   return a + '::' + b + '::' + c;
 });


### PR DESCRIPTION
The path module uses the path separator of the platform it runs on. This means that on Windows, backslashes are used instead of slashes, which is not supported by Chrome Devtools.
