### PR TITLE
Relative path manipulation handles Windows paths and different extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,14 +34,19 @@ var rebaseRelativePath = memoize(function(sourceFile, relativeRoot, relativePath
   // join relative path to root (e.g. 'src/' + 'file.js')
   var relativeRootedPath = relativeRoot ? path.join(relativeRoot, relativePath) : relativePath;
 
+  // Ultimately these will be used in URLs so normalise to URL path separators before comparison
+  relativeRootedPath = relativeRootedPath.replace(/\\/g, '/');
+  sourceFile = sourceFile.replace(/\\/g, '/');
+
   if (sourceFile === relativeRootedPath ||    // same path,
+      path.dirname(sourceFile) === path.dirname(relativeRootedPath) || // same dir, different file (e.g. foo.ts > foo.js)
       pathIsAbsolute(relativeRootedPath) ||   // absolute path, nor
       protocolRx.test(relativeRootedPath)) {  // absolute protocol need rebasing
     return relativeRootedPath;
   }
 
   // make relative to source file
-  return path.join(path.dirname(sourceFile), relativeRootedPath);
+  return path.join(path.dirname(sourceFile), relativeRootedPath).replace(/\\/g, '/');
 }, function(a, b, c) {
   return a + '::' + b + '::' + c;
 });

--- a/test/combine-source-map.js
+++ b/test/combine-source-map.js
@@ -345,3 +345,64 @@ test('remove comments', function (t) {
   })
   t.end()
 })
+
+test('relative path mainipulation copes with changing file extension', function (t) {
+
+  var foo = {
+    version        :  3,
+    file           :  'bar/foo.js',
+    sourceRoot     :  '',
+    sources        :  [ 'bar/foo.coffee' ],
+    names          :  [],
+    mappings       :  ';AAAA;CAAA;CAAA,CAAA,CAAA,IAAO,GAAK;CAAZ',
+    sourcesContent :  [ 'console.log(require \'./bar.js\')\n' ] };
+  
+  var mapComment = convert.fromObject(foo).toComment();
+
+  var file = {
+      id: 'xyz'
+    , source: '(function() {\n\n  console.log(require(\'./bar.js\'));\n\n}).call(this);\n' + '\n' + mapComment
+    , sourceFile: 'bar/foo.js'
+  };
+
+  var lineOffset = 3
+  var base64 = combine.create()
+    .addFile(file, { line: lineOffset })
+    .base64()
+
+  var sm = convert.fromBase64(base64).toObject();
+
+  t.deepEqual(sm.sources, ['bar/foo.coffee'], 'includes original relative file path')
+  t.end()
+})
+
+test('relative path mainipulation generates paths with URL path separators', function (t) {
+
+  var foo = {
+    version        :  3,
+    file           :  'bar/foo.js',
+    sourceRoot     :  '',
+    sources        :  [ 'bar\\foo.coffee' ],
+    names          :  [],
+    mappings       :  ';AAAA;CAAA;CAAA,CAAA,CAAA,IAAO,GAAK;CAAZ',
+    sourcesContent :  [ 'console.log(require \'./bar.js\')\n' ] };
+  
+  var mapComment = convert.fromObject(foo).toComment();
+
+  var file = {
+      id: 'xyz'
+    , source: '(function() {\n\n  console.log(require(\'./bar.js\'));\n\n}).call(this);\n' + '\n' + mapComment
+    , sourceFile: 'bar/foo.js'
+  };
+
+  var lineOffset = 3
+  var base64 = combine.create()
+    .addFile(file, { line: lineOffset })
+    .base64()
+
+  var sm = convert.fromBase64(base64).toObject();
+  var res = checkMappings(foo, sm, lineOffset);
+
+  t.deepEqual(sm.sources, ['bar/foo.coffee'], 'includes relative file ulr path')
+  t.end()
+})


### PR DESCRIPTION
Fixes two problems when combining source maps that already have a relative path.

The first problem is when the extensions differ.  e.g.  A Typescript or Coffeescript compiler has converted `foo.ts` into `foo.js` and something upstream has given them relative paths. `bar/foo.ts` does not match `bar/foo.js` so the sources comes out as `bar/bar/foo.ts`

The second problem is doing the above on Windows. `bar\\foo.ts` does not match `bar/foo.js`.

Both occur when running Browserify on Windows on files generated by the Typescript compiler. Most files work ok, but ones _that contain node.js globals_ go through the `insert-module-globals` module which [generates a relative path](https://github.com/substack/insert-module-globals/blob/master/index.js#L163).  The path.join() in combine-source-maps is hit generating a Windows path which then causes the path comparison to fail when this code is hit again during `browser-pack`

The simplest fix seemed to be to ensure URL path separators everywhere and compare only on dirname. 

Tests added for both problems.   
