### PR TITLE
Ensure all comparisons within `rebaseRelativePath` handle Windows pat…

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ var protocolRx = /^[a-z]+:\/\//;
 /**
  * Rebases a relative path in 'sourceFile' to be relative
  * to the path where 'sourceFile' is located.
- * 
+ *
  * This is necessary before adding relative paths to the
  * new combined map to ensure all paths are relative to their
  * original source.
- * 
+ *
  * The 'sourceRoot' from the original source map is joined
  * as well to ensure the complete path.
  *
@@ -32,7 +32,9 @@ var rebaseRelativePath = memoize(function(sourceFile, relativeRoot, relativePath
   }
 
   // join relative path to root (e.g. 'src/' + 'file.js')
-  var relativeRootedPath = relativeRoot ? path.join(relativeRoot, relativePath).replace(/\\/g, '/') : relativePath;
+  var relativeRootedPath = relativeRoot ? path.join(relativeRoot, relativePath) : relativePath;
+  relativeRootedPath = relativeRootedPath.replace(/\\/g, '/');
+  sourceFile = sourceFile.replace(/\\/g, '/');
 
   if (sourceFile === relativeRootedPath ||    // same path,
       pathIsAbsolute(relativeRootedPath) ||   // absolute path, nor


### PR DESCRIPTION
…hs (as in #23).

#23 handled this aspect more completely, so adding as a PR to confirm you are ok with these changes too (still related to Windows paths).

Builds on #21