### PR TITLE
Update convert-source-map to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/thlorenz/combine-source-map",
   "dependencies": {
-    "convert-source-map": "~1.1.0",
+    "convert-source-map": "~1.5.1",
     "inline-source-map": "~0.6.0",
     "lodash.memoize": "~3.0.3",
     "source-map": "~0.5.3"


### PR DESCRIPTION
See https://github.com/browserify/browserify/issues/1808 for more information.
convert-source-map has a bug fix that fixes a bug in browserify
(sourceMappingURL being removed from template strings), but this package is
on an old convert-source-map. Updating this package and publishing as a patch
update will make everything work. Publishing as a minor update would mean that
browser-pack needs have its combine-source-map dependency updated, but that
should also be fine.