### PR TITLE
fix: replace deprecated lodash.memoize with lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var path            =  require('path');
 var convert         =  require('convert-source-map');
-var memoize         =  require('lodash.memoize');
+var memoize         =  require('lodash').memoize;
 var createGenerator =  require('inline-source-map');
 var pathIsAbsolute  =  require('./lib/path-is-absolute');
 var mappingsFromMap =  require('./lib/mappings-from-map');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "convert-source-map": "~1.1.0",
     "inline-source-map": "~0.6.0",
-    "lodash.memoize": "^4.1.2",
+    "lodash": "^4.17.21",
     "source-map": "~0.5.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "convert-source-map": "~1.1.0",
     "inline-source-map": "~0.6.0",
-    "lodash.memoize": "~3.0.3",
+    "lodash.memoize": "^4.1.2",
     "source-map": "~0.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace deprecated `lodash.memoize` with `lodash`.

https://github.com/lodash/lodash/issues/5896#issuecomment-2206176135

> See https://lodash.com/per-method-packages and https://github.com/lodash/lodash/issues/5738#issuecomment-1737782579